### PR TITLE
Support for PHP8 and update of reverse search API endpoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     ],
     "type": "library",
     "require": {
-        "php": "^7.0",
+        "php": "^7.0|^8.0",
         "geocoder-php/common-http": "^4.0",
         "willdurand/geocoder": "^4.0"
     },
     "require-dev": {
-		"phpunit/phpunit": "6.*",
+		"phpunit/phpunit": "^9.3.0",
         "php-http/message": "^1.0",
-        "php-http/curl-client": "^1.7",
-        "nyholm/psr7": "^0.2.2",
+        "php-http/curl-client": "^2.2",
+        "nyholm/psr7": "^1.3.1",
         "geocoder-php/provider-integration-tests": "^1.1"
     },
     "provide": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "type": "library",
     "require": {
-        "php": "^7.0|^8.0",
+        "php": "^7.4|^8.0",
         "geocoder-php/common-http": "^4.0",
         "willdurand/geocoder": "^4.0"
     },

--- a/src/GeoportailProvider.php
+++ b/src/GeoportailProvider.php
@@ -21,7 +21,7 @@ class GeoportailProvider extends AbstractHttpProvider implements Provider {
         'https://apiv3.geoportail.lu/geocode/search?queryString=%s';
 
     const REVERSE_GEOCODE_URL_TEMPLATE =
-        'https://api.geoportail.lu/geocoder/reverseGeocode?lon=%s&lat=%s';
+        'https://apiv3.geoportail.lu/geocode/reverse?lon=%s&lat=%s';
 
     /**
      * @param HttpClient $client


### PR DESCRIPTION
PHP versions < 7.4 are not officially supported anymore and the current composer file does not support PHP 8. This PR fixes this problem and updates the API endpoint (v3) for reverse search.

All tests passed successfully.